### PR TITLE
feat: add open source best practices (CONTRIBUTING, SECURITY, templates, Pester tests, CI integration)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+A clear and concise description of what the bug is.
+
+## Environment Info
+- **OS Version:** 
+- **PowerShell Version:** 
+- **Project Version / Commit Hash:** 
+
+## Steps to Reproduce
+Steps to reproduce the behavior:
+1. Run command '...'
+2. Set configuration '...'
+3. See error
+
+## Expected Behavior
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+A clear and concise description of what actually happened (include error messages or screenshot).
+
+## Additional Context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem Description
+A clear and concise description of what the problem is. E.g. I'm always frustrated when [...]
+
+## Proposed Solution
+A clear and concise description of what you want to happen.
+
+## Alternative Ideas
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional Context
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Description
+Please include a summary of the changes and the related issue(s). List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of Change
+Please delete options that are not relevant.
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+## Verification & Testing
+Describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+- [ ] Test A
+- [ ] Test B
+
+## Checklist:
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,10 @@ jobs:
           } else {
               Write-Output "There were $($errors.Count) errors and $($warnings.Count) warnings total."
           }
+      - name: Run Pester tests
+        shell: pwsh
+        run: |
+          $result = Invoke-Pester -Path tests/ -PassThru
+          if ($result.FailedCount -gt 0) {
+              throw "$($result.FailedCount) tests failed."
+          }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,187 @@
+# Contributing to Windows Secure Auditor
+
+First off, thank you for considering contributing to Windows Secure Auditor! It's people like you that make it a great tool.
+
+This guide outlines the process and conventions for contributing to the project.
+
+## Table of Contents
+1. [Reporting Bugs](#reporting-bugs)
+2. [Suggesting Features](#suggesting-features)
+3. [Running Tests & Linting](#running-tests--linting)
+4. [Writing Custom Rules](#writing-custom-rules)
+5. [Submitting Pull Requests](#submitting-pull-requests)
+
+---
+
+## Reporting Bugs
+
+If you find a bug, please check the existing issues to see if it has already been reported. If not, open a new issue and include as much detail as possible:
+*   **Operating System:** Exact Windows version/edition (e.g., Windows Server 2019 Datacenter).
+*   **PowerShell Version:** Output of `$PSVersionTable.PSVersion`.
+*   **Steps to Reproduce:** Clear instructions on how to trigger the bug.
+*   **Actual vs. Expected Behavior:** What happened, and what you expected to happen instead.
+*   **Logs/Output:** Any error messages, stack traces, or relevant console output.
+
+---
+
+## Suggesting Features
+
+We welcome ideas for new features and audit rules! To suggest a feature:
+1.  Check the existing issues to ensure it hasn't been requested already.
+2.  Open a new issue describing:
+    *   The problem you want to solve.
+    *   The proposed solution or rule implementation.
+    *   Any relevant security baseline or reference (e.g., CIS Benchmarks, Microsoft Security Baselines).
+
+---
+
+## Running Tests & Linting
+
+Before submitting your code, make sure it is tested and follows the project's coding standards.
+
+### 1. Manual Testing
+Run the main script to verify your changes do not break the execution and output correct Markdown:
+```powershell
+# Run the auditor
+.\SecureAuditor.ps1
+
+# Run with verbose logging to inspect execution details
+.\SecureAuditor.ps1 -Verbose
+```
+
+### 2. Linting (PSScriptAnalyzer)
+We use [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) to enforce code quality and styling. The settings are defined in `PSScriptAnalyzerSettings.psd1`.
+
+To run the linter locally:
+1.  Install the module (if not already installed):
+    ```powershell
+    Install-Module PSScriptAnalyzer -Scope CurrentUser -Force
+    ```
+2.  Run the analyzer on the repository:
+    ```powershell
+    Invoke-ScriptAnalyzer -Path . -Settings PSScriptAnalyzerSettings.psd1 -Recurse
+    ```
+Ensure there are no errors or warnings before committing your changes.
+
+---
+
+## Writing Custom Rules
+
+Windows Secure Auditor is built to be extensible. You can add new rules by creating a PowerShell script module (`.psm1`) in the `rules/` directory.
+
+### Rule Directory Structure
+Rules can be added directly under `rules/` or in a subdirectory (e.g., `rules/WinEvent/`) for organization:
+```
+rules/
+├── zh-TW/                  # Root-level rules localization
+│   └── MyRule.psd1
+├── MyRule.psm1             # Rule module file
+└── SubCategory/
+    ├── zh-TW/              # Sub-category rules localization
+    │   └── SubRule.psd1
+    └── SubRule.psm1        # Sub-category rule module file
+```
+
+### Step-by-Step Guide to Adding a Rule
+
+#### 1. Define Configuration in `SecureAuditor.ini`
+If your rule requires settings or parameters, add a new section to `SecureAuditor.ini`:
+```ini
+[MyRule]
+Enabled = true
+MaxLimit = 5
+```
+
+#### 2. Create the Rule Module (`rules/MyRule.psm1`)
+Create your rule script module. Every rule module must implement and export a `Test` function that accepts a `$config` parameter:
+
+```powershell
+# rules/MyRule.psm1
+
+# 1. Define localizable strings (default: en-US)
+$i18n = Data {
+    # culture="en-US"
+    ConvertFrom-StringData @'
+    Header = My Custom Security Check
+    ItemDescription = Validation check of MyRule limit
+'@
+}
+
+# 2. Import localized strings if the UI culture is not en-US
+if ($PSUICulture -ne 'en-US') {
+    Import-LocalizedData -BindingVariable i18n
+}
+
+# 3. Implement the Test function
+function Test($config) {
+    $ruleName = [System.IO.Path]::GetFileNameWithoutExtension($PSCommandPath)
+
+    # (Optional) Check for platform support
+    if ($PSVersionTable.PSEdition -eq 'Core' -and $PSVersionTable.Platform -ne 'Win32NT') {
+        Write-UnsupportedPlatform($ruleName)
+        return
+    }
+
+    # (Optional) Check for Administrator privileges
+    if (-not (IsLocalAdministrator)) {
+        Write-RequireAdministrator($ruleName)
+        return
+    }
+
+    # (Optional) Respect the enabled/disabled status in configuration
+    # Note: SecureAuditor.ps1 automatically filters rules by Rules.Include/Rules.Exclude,
+    # but rule-specific Enabled flags should be checked inside the Test function.
+    if ($config.MyRule -and $config.MyRule.Enabled -eq 'false') {
+        return
+    }
+
+    # 4. Output the results in Markdown format
+    Write-Output "`n## $($i18n.Header)`n"
+
+    # Get configuration value
+    $limit = [int]$config.MyRule.MaxLimit
+
+    # Run check logic
+    $currentValue = 3 # (Replace with actual system check logic)
+    $isPass = $currentValue -le $limit
+
+    # 5. Use Write-CheckList to print standard pass/fail items
+    # Format: Write-CheckList [bool] "message"
+    Write-CheckList $isPass "$($i18n.ItemDescription): $currentValue <= $limit"
+}
+```
+
+#### 3. Create Translation File (`rules/zh-TW/MyRule.psd1`)
+To support translations, create a corresponding folder and `.psd1` file under `rules/zh-TW/`:
+```powershell
+# rules/zh-TW/MyRule.psd1
+# culture="zh-TW"
+ConvertFrom-StringData -StringData @'
+Header = 我的自訂安全檢查
+ItemDescription = MyRule 限制驗證檢查
+'@
+```
+
+### Shared Helper Functions
+The main module (`SecureAuditor.psm1`) provides several helper functions that you can use in your rules:
+*   `IsLocalAdministrator()`: Returns `$true` if the current process is running with elevated Administrator privileges.
+*   `Write-RequireAdministrator($ruleName)`: Prints a standard warning that the rule was skipped because it requires Administrator privileges.
+*   `Write-UnsupportedPlatform($ruleName)`: Prints a standard warning that the rule was skipped because the OS platform is unsupported.
+*   `Write-CheckList([bool]$pass, [string]$item)`: Outputs a checklist item formatted in Markdown: `- [x] Item` (pass) or `- [ ] Item` (fail).
+
+---
+
+## Submitting Pull Requests
+
+1.  **Fork the repository** and create your branch from `main`:
+    ```bash
+    git checkout -b feature/my-new-rule
+    ```
+2.  **Keep changes focused.** Do not mix unrelated refactoring or formatting changes in your pull request.
+3.  **Run linting and manual tests** to verify that everything works and complies with project standards.
+4.  **Commit your changes** using descriptive and structured messages:
+    ```bash
+    git add .
+    git commit -m "feat: add MyRule for monitoring xyz"
+    ```
+5.  **Push to your branch** and open a **Pull Request** to the `main` branch. Provide a clear description of the changes and reference any related issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of **Windows Secure Auditor** are currently supported with security updates:
+
+| Version | Supported |
+| ------- | --------- |
+| 1.x     | :white_check_mark: Yes |
+| < 1.0   | :x: No |
+
+## Reporting a Vulnerability
+
+We take the security of this project seriously. If you believe you have found a security vulnerability in this project, please report it to us privately rather than opening a public issue on GitHub.
+
+Please use the **[GitHub Private Vulnerability Reporting](https://github.com/akunzai/windows-secure-auditor/security/advisories/new)** feature to submit your report.
+
+Please include the following details in your report:
+- A description of the vulnerability.
+- Steps to reproduce the vulnerability, including a proof of concept if available.
+- Any potential impact of the vulnerability.
+
+We will acknowledge receipt of your vulnerability report within 48 hours and work with you to resolve the issue as quickly as possible. Once the issue is resolved and a patch is released, we will coordinate public disclosure.

--- a/tests/SecureAuditor.Tests.ps1
+++ b/tests/SecureAuditor.Tests.ps1
@@ -1,0 +1,32 @@
+BeforeAll {
+    Import-Module $PSScriptRoot/../SecureAuditor.psm1 -Force
+}
+
+Describe "SecureAuditor Module" {
+    Context "Get-IniContent" {
+        It "should return empty hashtable if file does not exist" {
+            $result = Get-IniContent -filePath "nonexistent_file.ini"
+            $result.Count | Should -Be 0
+        }
+
+        It "should parse sections and keys correctly" {
+            $tempFile = [System.IO.Path]::GetTempFileName()
+            @'
+[SystemInfo]
+Enabled = 1
+
+[Rules]
+Exclude = RuleA
+'@ | Out-File -FilePath $tempFile -Encoding utf8
+
+            try {
+                $result = Get-IniContent -filePath $tempFile
+                $result.SystemInfo.Enabled | Should -Be "1"
+                $result.Rules.Exclude | Should -Be "RuleA"
+            }
+            finally {
+                Remove-Item $tempFile -Force
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added `CONTRIBUTING.md` and `SECURITY.md` for open source guidance.
- Added issue templates (bug report, feature request) and pull request template under `.github/`.
- Added Pester unit tests for `Get-IniContent` in `tests/SecureAuditor.Tests.ps1`.
- Integrated Pester tests into `.github/workflows/build.yml` CI workflow.

## Test Plan
- Run Pester tests locally: `DOTNET_ROLL_FORWARD=Major pwsh -Command "Invoke-Pester -Path tests/ -Output Detailed"`